### PR TITLE
WIP: Add attacker operator loadouts

### DIFF
--- a/src/operators/ace/index.ts
+++ b/src/operators/ace/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const ace = {
   slug: 'ace',
@@ -21,7 +27,33 @@ export const ace = {
   ratings: { health: 2, speed: 2 },
   specialties: ['anti-gadget', 'breach'],
   season: { id: 18 },
-  weapons: { primary: ['ak-12', 'm1014'], secondary: ['p9'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'ak-12',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'm1014',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'p9',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['breach_charge', 'claymore'] },
   uniqueAbility: {
     slug: 's.e.l.m.a._aqua_breacher',

--- a/src/operators/amaru/index.ts
+++ b/src/operators/amaru/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const amaru = {
   slug: 'amaru',
@@ -22,8 +28,51 @@ export const amaru = {
   specialties: ['front-line', 'map_control'],
   season: { id: 15 },
   weapons: {
-    primary: ['g8a1', 'supernova'],
-    secondary: ['smg-11', 'ita12s', 'gonne-6']
+    primary: [
+      {
+        slug: 'g8a1',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'supernova',
+        sights: COMMON_SIGHTS_1X,
+        barrels: ['suppressor'],
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'smg-11',
+        sights: COMMON_SIGHTS_1X,
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'ita12s',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gonne-6',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      }
+    ]
   },
   gadgets: { secondary: ['hard_breach_charge', 'stun_grenade'] },
   uniqueAbility: {

--- a/src/operators/ash/index.ts
+++ b/src/operators/ash/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const ash = {
   slug: 'ash',
@@ -21,7 +27,40 @@ export const ash = {
   ratings: { health: 1, speed: 3 },
   specialties: ['breach', 'front-line'],
   season: { id: 0 },
-  weapons: { primary: ['g36c', 'r4-c'], secondary: ['5.7_usg', 'm45_meusoc'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'g36c',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'r4-c',
+        sights: COMMON_SIGHTS_1X,
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: '5.7_usg',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'm45_meusoc',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['breach_charge', 'claymore'] },
   uniqueAbility: {
     slug: 'breaching_rounds',

--- a/src/operators/blackbeard/index.ts
+++ b/src/operators/blackbeard/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const blackbeard = {
   slug: 'blackbeard',
@@ -21,7 +27,40 @@ export const blackbeard = {
   ratings: { health: 2, speed: 2 },
   specialties: ['support'],
   season: { id: 2 },
-  weapons: { primary: ['mk17_cqb', 'sr-25'], secondary: ['d-50'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'mk17_cqb',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'sr-25',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b',
+          'scope_3.0x'
+        ],
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'd-50',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['claymore', 'stun_grenade', 'impact_emp_grenade'] },
   uniqueAbility: {
     slug: 'rifle_shield',

--- a/src/operators/blitz/index.ts
+++ b/src/operators/blitz/index.ts
@@ -1,5 +1,6 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import { COMMON_BARRELS_HANDGUN_OR_MARKSMAN } from '../constants';
 
 export const blitz = {
   slug: 'blitz',
@@ -21,7 +22,26 @@ export const blitz = {
   ratings: { health: 2, speed: 2 },
   specialties: ['front-line', 'map_control'],
   season: { id: 0 },
-  weapons: { primary: ['g52-tactical_shield'], secondary: ['p12'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'g52-tactical_shield',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      }
+    ],
+    secondary: [
+      {
+        slug: 'p12',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['smoke_grenade', 'breach_charge'] },
   uniqueAbility: {
     slug: 'flash_shield',

--- a/src/operators/buck/index.ts
+++ b/src/operators/buck/index.ts
@@ -1,5 +1,10 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const buck = {
   slug: 'buck',
@@ -21,7 +26,49 @@ export const buck = {
   ratings: { health: 2, speed: 2 },
   specialties: ['breach', 'support'],
   season: { id: 1 },
-  weapons: { primary: ['c8-sfw', 'camrs'], secondary: ['mk1_9mm', 'gonne-6'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'c8-sfw',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS,
+        grips: null,
+        // NOTE: forced under-barrel shotgun
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'camrs',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b',
+          'scope_3.0x'
+        ],
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        // NOTE: forced under-barrel shotgun
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'mk1_9mm',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gonne-6',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      }
+    ]
+  },
   gadgets: { secondary: ['stun_grenade', 'hard_breach_charge'] },
   uniqueAbility: {
     slug: 'skeleton_key',

--- a/src/operators/capitao/index.ts
+++ b/src/operators/capitao/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const capitao = {
   slug: 'capitao',
@@ -21,7 +27,46 @@ export const capitao = {
   ratings: { health: 3, speed: 1 },
   specialties: ['front-line', 'map_control'],
   season: { id: 3 },
-  weapons: { primary: ['para-308', 'm249'], secondary: ['prb92', 'gonne-6'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'para-308',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'm249',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'prb92',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gonne-6',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      }
+    ]
+  },
   gadgets: { secondary: ['claymore', 'hard_breach_charge'] },
   uniqueAbility: {
     slug: 'tactical_crossbow',

--- a/src/operators/constants.ts
+++ b/src/operators/constants.ts
@@ -26,6 +26,13 @@ export const COMMON_BARRELS_HANDGUN_OR_MARKSMAN = [
   'suppressor'
 ] satisfies BarrelSlug[];
 
+export const COMMON_BARRELS_NO_EXTENDED_BARREL = [
+  'flash_hider',
+  'compensator',
+  'muzzle_brake',
+  'suppressor'
+] satisfies BarrelSlug[];
+
 export const COMMON_GRIPS = [
   'vertical_grip',
   'angled_grip'

--- a/src/operators/dokkaebi/index.ts
+++ b/src/operators/dokkaebi/index.ts
@@ -1,5 +1,10 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const dokkaebi = {
   slug: 'dokkaebi',
@@ -22,8 +27,58 @@ export const dokkaebi = {
   specialties: ['intel', 'map_control'],
   season: { id: 8 },
   weapons: {
-    primary: ['mk_14_ebr', 'bosg.12.2'],
-    secondary: ['smg-12', 'c75_auto', 'gonne-6']
+    primary: [
+      {
+        slug: 'mk_14_ebr',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b',
+          'scope_3.0x'
+        ],
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'bosg.12.2',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: null,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'smg-12',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'c75_auto',
+        sights: null,
+        barrels: ['suppressor'],
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gonne-6',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      }
+    ]
   },
   gadgets: {
     secondary: ['smoke_grenade', 'stun_grenade', 'impact_emp_grenade']

--- a/src/operators/ela/index.ts
+++ b/src/operators/ela/index.ts
@@ -3,7 +3,8 @@ import type { Operator } from '../types';
 import {
   COMMON_SIGHTS_1X,
   COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
-  COMMON_GRIPS
+  COMMON_GRIPS,
+  COMMON_BARRELS_NO_EXTENDED_BARREL
 } from '../constants';
 
 export const ela = {
@@ -31,7 +32,7 @@ export const ela = {
       {
         slug: 'scorpion_evo_3_a1',
         sights: COMMON_SIGHTS_1X,
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: COMMON_GRIPS,
         underBarrels: ['laser']
       },

--- a/src/operators/finka/index.ts
+++ b/src/operators/finka/index.ts
@@ -1,5 +1,12 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const finka = {
   slug: 'finka',
@@ -22,8 +29,52 @@ export const finka = {
   specialties: ['front-line', 'support'],
   season: { id: 9 },
   weapons: {
-    primary: ['spear_.308', '6p41', 'sasg-12'],
-    secondary: ['pmm', 'gsh-18', 'gonne-6']
+    primary: [
+      {
+        slug: 'spear_.308',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: '6p41',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'sasg-12',
+        sights: COMMON_SIGHTS_1X,
+        barrels: ['suppressor'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'pmm',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gsh-18',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gonne-6',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      }
+    ]
   },
   gadgets: { secondary: ['smoke_grenade', 'stun_grenade'] },
   uniqueAbility: {

--- a/src/operators/flores/index.ts
+++ b/src/operators/flores/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const flores = {
   slug: 'flores',
@@ -21,7 +27,40 @@ export const flores = {
   ratings: { health: 2, speed: 2 },
   specialties: ['anti-gadget', 'intel'],
   season: { id: 21 },
-  weapons: { primary: ['ar33', 'sr-25'], secondary: ['gsh-18'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'ar33',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'sr-25',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b',
+          'scope_3.0x'
+        ],
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'gsh-18',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['stun_grenade', 'claymore'] },
   uniqueAbility: {
     slug: 'rce-ratero_charge',

--- a/src/operators/fuze/index.ts
+++ b/src/operators/fuze/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const fuze = {
   slug: 'fuze',
@@ -22,8 +28,57 @@ export const fuze = {
   specialties: ['anti-gadget'],
   season: { id: 0 },
   weapons: {
-    primary: ['ballistic_shield', '6p41', 'ak-12'],
-    secondary: ['pmm', 'gsh-18']
+    primary: [
+      {
+        slug: 'ballistic_shield',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      },
+      {
+        slug: '6p41',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'ak-12',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'pmm',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gsh-18',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
   },
   gadgets: {
     secondary: ['breach_charge', 'hard_breach_charge', 'smoke_grenade']

--- a/src/operators/fuze/index.ts
+++ b/src/operators/fuze/index.ts
@@ -1,8 +1,8 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
 import {
-  COMMON_BARRELS,
   COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
   COMMON_GRIPS,
   COMMON_SIGHTS_1X
 } from '../constants';
@@ -45,7 +45,7 @@ export const fuze = {
           'scope_2.5x_a',
           'scope_2.5x_b'
         ],
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: COMMON_GRIPS,
         underBarrels: ['laser']
       },
@@ -58,7 +58,7 @@ export const fuze = {
           'scope_2.5x_a',
           'scope_2.5x_b'
         ],
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: COMMON_GRIPS,
         underBarrels: ['laser']
       }

--- a/src/operators/glaz/index.ts
+++ b/src/operators/glaz/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const glaz = {
   slug: 'glaz',
@@ -21,7 +27,50 @@ export const glaz = {
   ratings: { health: 1, speed: 3 },
   specialties: ['intel', 'support'],
   season: { id: 0 },
-  weapons: { primary: ['ots-03'], secondary: ['pmm', 'gonne-6', 'bearing_9'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'ots-03',
+        sights: [
+          'red_dot_a',
+          'red_dot_b',
+          'red_dot_c',
+          'holo_a',
+          'holo_b',
+          'holo_c',
+          'holo_d',
+          'reflex_a',
+          'reflex_b'
+        ],
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'pmm',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gonne-6',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      },
+      {
+        slug: 'bearing_9',
+        sights: COMMON_SIGHTS_1X,
+        barrels: COMMON_BARRELS,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['smoke_grenade', 'frag_grenade', 'claymore'] },
   uniqueAbility: {
     slug: 'flip_sight',

--- a/src/operators/gridlock/index.ts
+++ b/src/operators/gridlock/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const gridlock = {
   slug: 'gridlock',
@@ -22,8 +28,57 @@ export const gridlock = {
   specialties: ['support', 'map_control'],
   season: { id: 13 },
   weapons: {
-    primary: ['f90', 'm249_saw'],
-    secondary: ['super_shorty', 'sdp_9mm', 'gonne-6']
+    primary: [
+      {
+        slug: 'f90',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'm249_saw',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'super_shorty',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'sdp_9mm',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gonne-6',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      }
+    ]
   },
   gadgets: {
     secondary: ['smoke_grenade', 'breach_charge', 'impact_emp_grenade']

--- a/src/operators/hibana/index.ts
+++ b/src/operators/hibana/index.ts
@@ -1,5 +1,12 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const hibana = {
   slug: 'hibana',
@@ -22,8 +29,44 @@ export const hibana = {
   specialties: ['breach', 'front-line'],
   season: { id: 4 },
   weapons: {
-    primary: ['type-89', 'supernova'],
-    secondary: ['p229', 'bearing_9']
+    primary: [
+      {
+        slug: 'type-89',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'supernova',
+        sights: COMMON_SIGHTS_1X,
+        barrels: ['suppressor'],
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'p229',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'bearing_9',
+        sights: COMMON_SIGHTS_1X,
+        barrels: COMMON_BARRELS,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
   },
   gadgets: { secondary: ['stun_grenade', 'breach_charge'] },
   uniqueAbility: {

--- a/src/operators/iana/index.ts
+++ b/src/operators/iana/index.ts
@@ -1,5 +1,12 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const iana = {
   slug: 'iana',
@@ -21,7 +28,33 @@ export const iana = {
   ratings: { health: 2, speed: 2 },
   specialties: ['front-line', 'intel'],
   season: { id: 17 },
-  weapons: { primary: ['arx200', 'g36c'], secondary: ['mk1_9mm'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'arx200',
+        sights: COMMON_SIGHTS_1X,
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'g36c',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'mk1_9mm',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['frag_grenade', 'smoke_grenade'] },
   uniqueAbility: {
     slug: 'gemini_replicator',

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -91,7 +91,7 @@ export const MINI_OPERATORS = [
   thatcher,
   castle,
   pulse,
-  // ash,
+  ash,
   // thermite,
   doc,
   rook,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -106,7 +106,7 @@ export const MINI_OPERATORS = [
   blitz,
   iq,
   frost,
-  // buck,
+  buck,
   valkyrie,
   // blackbeard,
   caveira,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -100,7 +100,7 @@ export const MINI_OPERATORS = [
   kapkan,
   tachanka,
   glaz,
-  // fuze,
+  fuze,
   jager,
   bandit,
   // blitz,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -92,7 +92,7 @@ export const MINI_OPERATORS = [
   castle,
   pulse,
   ash,
-  // thermite,
+  thermite,
   doc,
   rook,
   // twitch,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -126,7 +126,7 @@ export const MINI_OPERATORS = [
   maestro,
   alibi,
   clash,
-  // maverick,
+  maverick,
   kaid,
   nomad,
   mozzie,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -88,7 +88,7 @@ export const MINI_OPERATORS = [
   smoke,
   mute,
   sledge,
-  // thatcher,
+  thatcher,
   castle,
   pulse,
   // ash,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -87,7 +87,7 @@ export const MINI_OPERATORS = [
   recruitAttack,
   smoke,
   mute,
-  // sledge,
+  sledge,
   // thatcher,
   castle,
   pulse,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -112,7 +112,7 @@ export const MINI_OPERATORS = [
   caveira,
   capitao,
   echo,
-  // hibana,
+  hibana,
   mira,
   // jackal,
   lesion,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -114,7 +114,7 @@ export const MINI_OPERATORS = [
   echo,
   hibana,
   mira,
-  // jackal,
+  jackal,
   lesion,
   ying,
   ela,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -103,7 +103,7 @@ export const MINI_OPERATORS = [
   fuze,
   jager,
   bandit,
-  // blitz,
+  blitz,
   // iq,
   frost,
   // buck,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -116,7 +116,7 @@ export const MINI_OPERATORS = [
   mira,
   // jackal,
   lesion,
-  // ying,
+  ying,
   ela,
   zofia,
   vigil,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -134,7 +134,7 @@ export const MINI_OPERATORS = [
   warden,
   // nokk,
   goyo,
-  // amaru,
+  amaru,
   wamai,
   kali,
   oryx,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -121,7 +121,7 @@ export const MINI_OPERATORS = [
   // zofia,
   vigil,
   // dokkaebi,
-  // lion,
+  lion,
   finka,
   maestro,
   alibi,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -122,7 +122,7 @@ export const MINI_OPERATORS = [
   vigil,
   // dokkaebi,
   // lion,
-  // finka,
+  finka,
   maestro,
   alibi,
   clash,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -143,7 +143,7 @@ export const MINI_OPERATORS = [
   // ace,
   // zero,
   aruni,
-  // flores,
+  flores,
   thunderbird,
   osa,
   thorn,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -96,7 +96,7 @@ export const MINI_OPERATORS = [
   doc,
   rook,
   twitch,
-  // montagne,
+  montagne,
   kapkan,
   tachanka,
   // glaz,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -108,7 +108,7 @@ export const MINI_OPERATORS = [
   frost,
   buck,
   valkyrie,
-  // blackbeard,
+  blackbeard,
   caveira,
   // capitao,
   echo,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -104,7 +104,7 @@ export const MINI_OPERATORS = [
   jager,
   bandit,
   blitz,
-  // iq,
+  iq,
   frost,
   // buck,
   valkyrie,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -141,7 +141,7 @@ export const MINI_OPERATORS = [
   // iana,
   melusi,
   // ace,
-  // zero,
+  zero,
   aruni,
   flores,
   thunderbird,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -130,7 +130,7 @@ export const MINI_OPERATORS = [
   kaid,
   // nomad,
   mozzie,
-  // gridlock,
+  gridlock,
   warden,
   nokk,
   goyo,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -136,7 +136,7 @@ export const MINI_OPERATORS = [
   goyo,
   // amaru,
   wamai,
-  // kali,
+  kali,
   oryx,
   iana,
   melusi,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -99,7 +99,7 @@ export const MINI_OPERATORS = [
   montagne,
   kapkan,
   tachanka,
-  // glaz,
+  glaz,
   // fuze,
   jager,
   bandit,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -95,7 +95,7 @@ export const MINI_OPERATORS = [
   thermite,
   doc,
   rook,
-  // twitch,
+  twitch,
   // montagne,
   kapkan,
   tachanka,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -145,7 +145,7 @@ export const MINI_OPERATORS = [
   aruni,
   // flores,
   thunderbird,
-  // osa,
+  osa,
   thorn,
   azami,
   // sens,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -132,7 +132,7 @@ export const MINI_OPERATORS = [
   mozzie,
   // gridlock,
   warden,
-  // nokk,
+  nokk,
   goyo,
   amaru,
   wamai,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -110,7 +110,7 @@ export const MINI_OPERATORS = [
   valkyrie,
   blackbeard,
   caveira,
-  // capitao,
+  capitao,
   echo,
   // hibana,
   mira,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -118,7 +118,7 @@ export const MINI_OPERATORS = [
   lesion,
   // ying,
   ela,
-  // zofia,
+  zofia,
   vigil,
   dokkaebi,
   lion,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -138,7 +138,7 @@ export const MINI_OPERATORS = [
   wamai,
   // kali,
   oryx,
-  // iana,
+  iana,
   melusi,
   ace,
   zero,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -120,7 +120,7 @@ export const MINI_OPERATORS = [
   ela,
   // zofia,
   vigil,
-  // dokkaebi,
+  dokkaebi,
   lion,
   finka,
   maestro,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -140,7 +140,7 @@ export const MINI_OPERATORS = [
   oryx,
   // iana,
   melusi,
-  // ace,
+  ace,
   zero,
   aruni,
   flores,

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -128,7 +128,7 @@ export const MINI_OPERATORS = [
   clash,
   // maverick,
   kaid,
-  // nomad,
+  nomad,
   mozzie,
   gridlock,
   warden,

--- a/src/operators/iq/index.ts
+++ b/src/operators/iq/index.ts
@@ -3,6 +3,7 @@ import type { Operator } from '../types';
 import {
   COMMON_BARRELS,
   COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
   COMMON_GRIPS,
   COMMON_SIGHTS_1X
 } from '../constants';
@@ -38,7 +39,7 @@ export const iq = {
           'scope_2.5x_a',
           'scope_2.5x_b'
         ],
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         // NOTE: forced vertical grip
         grips: null,
         underBarrels: ['laser']
@@ -53,7 +54,7 @@ export const iq = {
       {
         slug: 'g8a1',
         sights: COMMON_SIGHTS_1X,
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: COMMON_GRIPS,
         underBarrels: ['laser']
       }

--- a/src/operators/iq/index.ts
+++ b/src/operators/iq/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const iq = {
   slug: 'iq',
@@ -21,7 +27,47 @@ export const iq = {
   ratings: { health: 1, speed: 3 },
   specialties: ['intel', 'support'],
   season: { id: 0 },
-  weapons: { primary: ['aug_a2', '552_commando', 'g8a1'], secondary: ['p12'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'aug_a2',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        // NOTE: forced vertical grip
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: '552_commando',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'g8a1',
+        sights: COMMON_SIGHTS_1X,
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'p12',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['breach_charge', 'claymore'] },
   uniqueAbility: {
     slug: 'electronics_detector',

--- a/src/operators/jackal/index.ts
+++ b/src/operators/jackal/index.ts
@@ -1,5 +1,12 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const jackal = {
   slug: 'jackal',
@@ -22,8 +29,45 @@ export const jackal = {
   specialties: ['intel', 'map_control'],
   season: { id: 5 },
   weapons: {
-    primary: ['c7e', 'pdw9', 'ita12l'],
-    secondary: ['usp40', 'ita12s']
+    primary: [
+      {
+        slug: 'c7e',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'pdw9',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'ita12l',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'usp40',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'ita12s',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
   },
   gadgets: { secondary: ['claymore', 'smoke_grenade'] },
   uniqueAbility: {

--- a/src/operators/kali/index.ts
+++ b/src/operators/kali/index.ts
@@ -1,5 +1,10 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const kali = {
   slug: 'kali',
@@ -22,8 +27,40 @@ export const kali = {
   specialties: ['anti-gadget', 'support'],
   season: { id: 16 },
   weapons: {
-    primary: ['csrx_300'],
-    secondary: ['spsmg9', 'c75_auto', 'p226_mk_25']
+    primary: [
+      {
+        slug: 'csrx_300',
+        // NOTE: Forced 'scope_5.0x' and 'scope_12.0x'
+        sights: null,
+        barrels: null,
+        grips: null,
+        // NOTE: Forced launcher for LV Lances
+        underBarrels: null
+      }
+    ],
+    secondary: [
+      {
+        slug: 'spsmg9',
+        sights: COMMON_SIGHTS_1X,
+        barrels: COMMON_BARRELS,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'c75_auto',
+        sights: null,
+        barrels: ['suppressor'],
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'p226_mk_25',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
   },
   gadgets: { secondary: ['claymore', 'breach_charge'] },
   uniqueAbility: {

--- a/src/operators/lion/index.ts
+++ b/src/operators/lion/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const lion = {
   slug: 'lion',
@@ -22,8 +28,65 @@ export const lion = {
   specialties: ['intel', 'map_control'],
   season: { id: 9 },
   weapons: {
-    primary: ['v308', '417', 'sg-cqb'],
-    secondary: ['lfp586', 'p9', 'gonne-6']
+    primary: [
+      {
+        slug: 'v308',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: '417',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b',
+          'scope_3.0x'
+        ],
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'sg-cqb',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: ['vertical_grip'],
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'lfp586',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'p9',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gonne-6',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      }
+    ]
   },
   gadgets: { secondary: ['stun_grenade', 'claymore', 'impact_emp_grenade'] },
   uniqueAbility: {

--- a/src/operators/maestro/index.ts
+++ b/src/operators/maestro/index.ts
@@ -3,7 +3,8 @@ import type { Operator } from '../types';
 import {
   COMMON_SIGHTS_1X,
   COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
-  COMMON_GRIPS
+  COMMON_GRIPS,
+  COMMON_BARRELS_NO_EXTENDED_BARREL
 } from '../constants';
 
 export const maestro = {
@@ -31,7 +32,7 @@ export const maestro = {
       {
         slug: 'alda_5.56',
         sights: COMMON_SIGHTS_1X,
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: ['vertical_grip'],
         underBarrels: ['laser']
       },

--- a/src/operators/maverick/index.ts
+++ b/src/operators/maverick/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const maverick = {
   slug: 'maverick',
@@ -21,7 +27,40 @@ export const maverick = {
   ratings: { health: 1, speed: 3 },
   specialties: ['breach', 'front-line'],
   season: { id: 11 },
-  weapons: { primary: ['ar-15.50', 'm4'], secondary: ['1911_tacops'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'ar-15.50',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b',
+          'scope_3.0x'
+        ],
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'm4',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: '1911_tacops',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['stun_grenade', 'claymore'] },
   uniqueAbility: {
     slug: 'breaching_torch',

--- a/src/operators/montagne/index.ts
+++ b/src/operators/montagne/index.ts
@@ -1,5 +1,6 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import { COMMON_BARRELS_HANDGUN_OR_MARKSMAN } from '../constants';
 
 export const montagne = {
   slug: 'montagne',
@@ -21,7 +22,33 @@ export const montagne = {
   ratings: { health: 3, speed: 1 },
   specialties: ['intel', 'support'],
   season: { id: 0 },
-  weapons: { primary: ['le_roc_shield'], secondary: ['p9', 'lfp586'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'le_roc_shield',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: null
+      }
+    ],
+    secondary: [
+      {
+        slug: 'p9',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'lfp586',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: {
     secondary: ['smoke_grenade', 'hard_breach_charge', 'impact_emp_grenade']
   },

--- a/src/operators/nokk/index.ts
+++ b/src/operators/nokk/index.ts
@@ -1,5 +1,10 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const nokk = {
   slug: 'nokk',
@@ -21,7 +26,40 @@ export const nokk = {
   ratings: { health: 2, speed: 2 },
   specialties: ['front-line', 'map_control'],
   season: { id: 14 },
-  weapons: { primary: ['fmg-9', 'six12_sd'], secondary: ['5.7_usg', 'd-50'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'fmg-9',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'six12_sd',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: '5.7_usg',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'd-50',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: {
     secondary: ['frag_grenade', 'hard_breach_charge', 'impact_emp_grenade']
   },

--- a/src/operators/nomad/index.ts
+++ b/src/operators/nomad/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const nomad = {
   slug: 'nomad',
@@ -22,8 +28,45 @@ export const nomad = {
   specialties: ['front-line', 'map_control'],
   season: { id: 12 },
   weapons: {
-    primary: ['ak-74m', 'arx200'],
-    secondary: ['.44_mag_semi-auto', 'prb92']
+    primary: [
+      {
+        slug: 'ak-74m',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'arx200',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: '.44_mag_semi-auto',
+        // NOTE: Forced scope_3.0x_.44_mag
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'prb92',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
   },
   gadgets: { secondary: ['stun_grenade', 'breach_charge'] },
   uniqueAbility: {

--- a/src/operators/osa/index.ts
+++ b/src/operators/osa/index.ts
@@ -1,5 +1,12 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const osa = {
   slug: 'osa',
@@ -21,7 +28,39 @@ export const osa = {
   ratings: { health: 3, speed: 1 },
   specialties: ['intel', 'support'],
   season: { id: 23 },
-  weapons: { primary: ['556xi', 'pdw9'], secondary: ['pmm'] },
+  weapons: {
+    primary: [
+      {
+        slug: '556xi',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'pdw9',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'pmm',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['smoke_grenade', 'claymore', 'impact_emp_grenade'] },
   uniqueAbility: {
     slug: 'talon-8_clear_shield',

--- a/src/operators/sledge/index.ts
+++ b/src/operators/sledge/index.ts
@@ -1,5 +1,10 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const sledge = {
   slug: 'sledge',
@@ -22,8 +27,31 @@ export const sledge = {
   specialties: ['anti-gadget', 'breach'],
   season: { id: 0 },
   weapons: {
-    primary: ['l85a2', 'm590a1'],
-    secondary: ['p226_mk_25', 'smg-11']
+    primary: [
+      {
+        slug: 'l85a2',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'm590a1',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'p226_mk_25',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
   },
   gadgets: {
     secondary: ['frag_grenade', 'stun_grenade', 'impact_emp_grenade']

--- a/src/operators/sledge/index.ts
+++ b/src/operators/sledge/index.ts
@@ -2,6 +2,7 @@ import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
 import {
   COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
   COMMON_GRIPS,
   COMMON_SIGHTS_1X
 } from '../constants';
@@ -31,7 +32,7 @@ export const sledge = {
       {
         slug: 'l85a2',
         sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: COMMON_GRIPS,
         underBarrels: ['laser']
       },

--- a/src/operators/thatcher/index.ts
+++ b/src/operators/thatcher/index.ts
@@ -2,6 +2,7 @@ import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
 import {
   COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
   COMMON_GRIPS,
   COMMON_SIGHTS_1X
 } from '../constants';
@@ -37,14 +38,14 @@ export const thatcher = {
           'scope_2.5x_a',
           'scope_2.5x_b'
         ],
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: COMMON_GRIPS,
         underBarrels: ['laser']
       },
       {
         slug: 'l85a2',
         sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: COMMON_GRIPS,
         underBarrels: ['laser']
       },

--- a/src/operators/thatcher/index.ts
+++ b/src/operators/thatcher/index.ts
@@ -1,5 +1,10 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const thatcher = {
   slug: 'thatcher',
@@ -21,7 +26,46 @@ export const thatcher = {
   ratings: { health: 3, speed: 1 },
   specialties: ['anti-gadget', 'support'],
   season: { id: 0 },
-  weapons: { primary: ['ar33', 'l85a2', 'm590a1'], secondary: ['p226_mk_25'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'ar33',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'l85a2',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'm590a1',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'p226_mk_25',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['breach_charge', 'claymore'] },
   uniqueAbility: {
     slug: 'emp_grenade',

--- a/src/operators/thermite/index.ts
+++ b/src/operators/thermite/index.ts
@@ -1,5 +1,10 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const thermite = {
   slug: 'thermite',
@@ -22,8 +27,44 @@ export const thermite = {
   specialties: ['breach', 'support'],
   season: { id: 0 },
   weapons: {
-    primary: ['m1014', '556xi'],
-    secondary: ['5.7_usg', 'm45_meusoc']
+    primary: [
+      {
+        slug: 'm1014',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: '556xi',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'm45_meusoc',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: '5.7_usg',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
   },
   gadgets: { secondary: ['smoke_grenade', 'stun_grenade'] },
   uniqueAbility: {

--- a/src/operators/thermite/index.ts
+++ b/src/operators/thermite/index.ts
@@ -2,6 +2,7 @@ import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
 import {
   COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
   COMMON_GRIPS,
   COMMON_SIGHTS_1X
 } from '../constants';
@@ -44,7 +45,7 @@ export const thermite = {
           'scope_2.5x_a',
           'scope_2.5x_b'
         ],
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: COMMON_GRIPS,
         underBarrels: ['laser']
       }

--- a/src/operators/twitch/index.ts
+++ b/src/operators/twitch/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS,
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const twitch = {
   slug: 'twitch',
@@ -21,7 +27,54 @@ export const twitch = {
   ratings: { health: 2, speed: 2 },
   specialties: ['anti-gadget', 'intel'],
   season: { id: 0 },
-  weapons: { primary: ['f2', '417', 'sg-cqb'], secondary: ['p9', 'lfp586'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'f2',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: '417',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b',
+          'scope_3.0x'
+        ],
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'sg-cqb',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: ['vertical_grip'],
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'p9',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'lfp586',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['smoke_grenade', 'claymore'] },
   uniqueAbility: {
     slug: 'shock_drones',

--- a/src/operators/wamai/index.ts
+++ b/src/operators/wamai/index.ts
@@ -3,7 +3,8 @@ import type { Operator } from '../types';
 import {
   COMMON_SIGHTS_1X,
   COMMON_BARRELS,
-  COMMON_BARRELS_HANDGUN_OR_MARKSMAN
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL
 } from '../constants';
 
 export const wamai = {
@@ -31,7 +32,7 @@ export const wamai = {
       {
         slug: 'aug_a2',
         sights: COMMON_SIGHTS_1X,
-        barrels: ['flash_hider', 'compensator', 'muzzle_brake', 'suppressor'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
         grips: null,
         underBarrels: ['laser']
       },

--- a/src/operators/ying/index.ts
+++ b/src/operators/ying/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const ying = {
   slug: 'ying',
@@ -21,7 +27,39 @@ export const ying = {
   ratings: { health: 2, speed: 2 },
   specialties: ['front-line', 'map_control'],
   season: { id: 7 },
-  weapons: { primary: ['t-95_lsw', 'six12'], secondary: ['q-929'] },
+  weapons: {
+    primary: [
+      {
+        slug: 't-95_lsw',
+        sights: [
+          ...COMMON_SIGHTS_1X,
+          'scope_1.5x',
+          'scope_2.0x',
+          'scope_2.5x_a',
+          'scope_2.5x_b'
+        ],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'six12',
+        sights: COMMON_SIGHTS_1X,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'q-929',
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['smoke_grenade', 'hard_breach_charge'] },
   uniqueAbility: {
     slug: 'candela',

--- a/src/operators/zero/index.ts
+++ b/src/operators/zero/index.ts
@@ -1,5 +1,6 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import { COMMON_BARRELS, COMMON_GRIPS, COMMON_SIGHTS_1X } from '../constants';
 
 export const zero = {
   slug: 'zero',
@@ -21,7 +22,42 @@ export const zero = {
   ratings: { health: 1, speed: 3 },
   specialties: ['anti-gadget', 'intel'],
   season: { id: 19 },
-  weapons: { primary: ['sc3000k', 'mp7'], secondary: ['5.7_usg', 'gonne-6'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'sc3000k',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'mp7',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x'],
+        barrels: COMMON_BARRELS,
+        // NOTE: Forced vertical grip
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: '5.7_usg',
+        sights: null,
+        // NOTE: Forced suppressor
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'gonne-6',
+        sights: null,
+        barrels: null,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['hard_breach_charge', 'claymore'] },
   uniqueAbility: {
     slug: 'argus_launcher',

--- a/src/operators/zofia/index.ts
+++ b/src/operators/zofia/index.ts
@@ -1,5 +1,11 @@
 import { getOperatorAssetURL, getOperatorSVGString } from '../utils';
 import type { Operator } from '../types';
+import {
+  COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+  COMMON_BARRELS_NO_EXTENDED_BARREL,
+  COMMON_GRIPS,
+  COMMON_SIGHTS_1X
+} from '../constants';
 
 export const zofia = {
   slug: 'zofia',
@@ -21,7 +27,34 @@ export const zofia = {
   ratings: { health: 3, speed: 1 },
   specialties: ['breach', 'anti-gadget'],
   season: { id: 8 },
-  weapons: { primary: ['lmg-e', 'm762'], secondary: ['rg15'] },
+  weapons: {
+    primary: [
+      {
+        slug: 'lmg-e',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      },
+      {
+        slug: 'm762',
+        sights: [...COMMON_SIGHTS_1X, 'scope_1.5x', 'scope_2.0x'],
+        barrels: COMMON_BARRELS_NO_EXTENDED_BARREL,
+        grips: COMMON_GRIPS,
+        underBarrels: ['laser']
+      }
+    ],
+    secondary: [
+      {
+        slug: 'rg15',
+        // NOTE: Forced red_dot_handgun
+        sights: null,
+        barrels: COMMON_BARRELS_HANDGUN_OR_MARKSMAN,
+        grips: null,
+        underBarrels: ['laser']
+      }
+    ]
+  },
   gadgets: { secondary: ['breach_charge', 'claymore'] },
   uniqueAbility: {
     slug: 'ks79_lifeline',


### PR DESCRIPTION
## Describe your changes

<!-- Please describe the changes this PR makes and why it should be merged -->
Work towards implementing #1

Refactors attacker operator's loadouts (not done for all of them yet). 
Also adds the `COMMON_BARRELS_NO_EXTENDED_BARREL` constant, as described [here](https://github.com/danielwerg/r6data/issues/1#issuecomment-1445010802). However, I intentionally didn't rename `COMMON_BARRELS` as it would have resulted in a very large diff.

Refactoring done for:
 - [x] Pathfinders
 - [x] Y1
 - [x] Y2
 - [x] Y3
 - [x] Y4
 - [x] Y5
 - [x] Y6
 - [x] Y7 (not in this PR)

As requested, maintainer edits are allowed 🔥 
<!-- Fixes # (issue)  -->
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
